### PR TITLE
ci: bump ansible version & change gh release action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 name: Build Docker
 
 env:
-  ANSIBLE_VERSION: 6.6.0-r0
+  ANSIBLE_VERSION: 7.5.0-r0
 
 on:
   push:
@@ -47,17 +47,16 @@ jobs:
       - name: Create Release
         id: create_release
         if: github.ref == 'refs/heads/main'
-        uses: actions/create-release@latest
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: ncipollo/release-action@v1
         with:
-          tag_name: 1.0.${{ github.run_number }}-ansible-${{ env.ANSIBLE_VERSION }}
-          release_name: Release v1.0.${{ github.run_number }}
+          tag: 1.0.${{ github.run_number }}-ansible-${{ env.ANSIBLE_VERSION }}
+          name: Release v1.0.${{ github.run_number }}
           body: |
             Image v1.0.${{ github.run_number }}
             Ansible Version : ${{ env.ANSIBLE_VERSION }}
           draft: false
           prerelease: false
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Push docker image release
         id: push_docker_release


### PR DESCRIPTION
I change the GitHub Action `actions/create-release` with `ncipollo/release-action` as the previous one is not maintained anymore : https://github.com/actions/create-release